### PR TITLE
Add option to process cached results.

### DIFF
--- a/searchbox/extractors.py
+++ b/searchbox/extractors.py
@@ -77,10 +77,10 @@ def body_text(response):
     return (title, text_data, html)
 
 
-def is_processable(response):
+def is_processable(response, process_cached=False):
     status_ok = response.status < 400 and response.status != 304
     is_cached = 'cached' in response.flags
-    return status_ok and not is_cached
+    return status_ok and (process_cached or not is_cached)
 
 
 def normalise_tag(tag_source: str) -> Iterable[str]:

--- a/searchbox/spiders/github_stars.py
+++ b/searchbox/spiders/github_stars.py
@@ -29,7 +29,7 @@ class GithubStarsSpider(scrapy.Spider):
             yield req
 
     def parse_stars(self, response):
-        if not is_processable(response):
+        if not is_processable(response, process_cached=True):
             return
 
         items = json.loads(response.text)

--- a/searchbox/spiders/gitlab_stars.py
+++ b/searchbox/spiders/gitlab_stars.py
@@ -33,7 +33,7 @@ class GitlabStarsSpider(scrapy.Spider):
             yield self._prepare_json_request(url, self.parse_user)
 
     def parse_user(self, response):
-        if not is_processable(response):
+        if not is_processable(response, process_cached=True):
             return
 
         users = json.loads(response.text)
@@ -43,7 +43,7 @@ class GitlabStarsSpider(scrapy.Spider):
             yield self._prepare_json_request(url, self.parse_stars)
 
     def parse_stars(self, response):
-        if not is_processable(response):
+        if not is_processable(response, process_cached=True):
             return
 
         try:


### PR DESCRIPTION
Add option to process cached results.

Some spiders will crawl paginated results starting on page 1, and following
`next` links, so if we skip processing the first page because it's unmodified,
we might not see the last page which contains new entries.